### PR TITLE
Add roster class and set members in class variable

### DIFF
--- a/chorebot.rb
+++ b/chorebot.rb
@@ -6,45 +6,28 @@ require_relative './lib/chores'
 
 NO_CHORE_LIST = %w(paul asross jordanking)
 
-def member_names
-  names = []
-  HTTParty.get(ENV['SLACK_MEMBERS_URL'])['members'].each do |m|
-    next unless m['profile']['email'] =~ /vermonster.com$/
-    next if m['deleted']
-    next if NO_CHORE_LIST.include?(m['name'])
-    names << m['name']
-  end
-  names
-end
-
 def chores
-  roster = member_names
   [
     TrashChore.new(
-      roster: roster,
       scheduling: WeeklyScheduling.new([:monday, :wednesday, :friday]),
       n_assignees: 2,
       offset: -8
     ),
     RecyclingChore.new(
-      roster: roster,
       scheduling: WeeklyScheduling.new([:monday, :thursday]),
       offset: -5
     ),
     DishChore.new(
-      roster: roster,
       scheduling: DailyScheduling.new,
       offset: -4
     ),
     PlantChore.new(
-      roster: roster,
       name: 'Bertha',
       heading: 'h.sl24hns7ta7c',
       image_path: "bertha.jpg",
       scheduling: MonthlyScheduling.new
     ),
     PlantChore.new(
-      roster: roster,
       name: 'Edward',
       heading: 'h.wlvxy5bc7z7d',
       image_path: "edward.jpg",
@@ -52,7 +35,6 @@ def chores
       offset: 1
     ),
     PlantChore.new(
-      roster: roster,
       name: 'Lula',
       heading: 'h.nvlbm0zacdtz',
       image_path: "lula.jpg",
@@ -60,7 +42,6 @@ def chores
       offset: 2
     ),
     PlantChore.new(
-      roster: roster,
       name: 'Chester',
       heading: 'h.7ymknjojnom7',
       image_path: 'chester.jpg',

--- a/lib/chores/base_chore.rb
+++ b/lib/chores/base_chore.rb
@@ -1,11 +1,14 @@
-class BaseChore
-  attr_reader :scheduling, :n_assignees, :offset, :roster
+require './lib/roster'
 
-  def initialize(scheduling:, roster:, n_assignees: 1, offset: 0)
+class BaseChore
+  include Roster
+  attr_reader :scheduling, :n_assignees, :offset
+
+  def initialize(scheduling:, n_assignees: 1, offset: 0)
     @scheduling = scheduling
     @n_assignees = n_assignees
     @offset = offset # to control which member starts, not anything date-related
-    @roster = roster
+    @@roster = member_names
   end
 
   def run_today?
@@ -19,7 +22,7 @@ class BaseChore
   def assignees_on(date)
     index = n_assignees * scheduling.run_index_on(date) + offset
     index.upto(index + n_assignees - 1).map do |i|
-      roster[i % roster.length]
+      select_member(@@roster, i)
     end
   end
 

--- a/lib/chores/plant_chore.rb
+++ b/lib/chores/plant_chore.rb
@@ -3,12 +3,11 @@ require_relative './base_chore'
 class PlantChore < BaseChore
   attr_reader :name, :heading, :image_path
 
-  def initialize(scheduling:, roster:, n_assignees: 1, offset: 0, name:, heading:, image_path:)
+  def initialize(scheduling:, n_assignees: 1, offset: 0, name:, heading:, image_path:)
     @name = name
     @scheduling = scheduling
     @n_assignees = n_assignees
     @offset = offset
-    @roster = roster
     @name = name
     @heading = heading
     @image_path = image_path

--- a/lib/roster.rb
+++ b/lib/roster.rb
@@ -1,0 +1,18 @@
+require 'httparty'
+
+module Roster
+  def select_member(roster, index)
+    roster.delete(roster[index % roster.length])
+  end
+
+  def member_names
+    names = []
+    HTTParty.get(ENV['SLACK_MEMBERS_URL'])['members'].each do |m|
+      next unless m['profile']['email'] =~ /vermonster.com$/
+      next if m['deleted']
+      next if NO_CHORE_LIST.include?(m['name'])
+      names << m['name']
+    end
+    names
+  end
+end

--- a/spec/chorebot_spec.rb
+++ b/spec/chorebot_spec.rb
@@ -103,3 +103,18 @@ describe WeeklyScheduling do
     end
   end
 end
+
+describe "Assigning team members to chores" do
+  module Roster
+    def member_names
+      1.upto(10).collect {|i| "Member #{i}"}
+    end
+  end
+
+  it "should not assign the same member to multiple chores" do
+    assignees = chores.select(&:run_today?).collect(&:assignees).flatten
+    remaining_roster = chores.select(&:run_today?).each(&:assignees).last.class.class_variable_get(:@@roster)
+
+    expect(assignees - remaining_roster).to eq assignees
+  end
+end


### PR DESCRIPTION
I removed individual roster instances from each class and converted the roster attribute to a class variable on BaseChore so that chores inherit changes made to `@@roster`. 

When a team member is selected from the roster for a chore, the member is deleted from the roster so that he or she is no longer considered for a second chore that day.
